### PR TITLE
Avoid generating network address (base IP) for /24 CIDR

### DIFF
--- a/classC-IP-gen.py
+++ b/classC-IP-gen.py
@@ -4,7 +4,7 @@ def generate_class_c_ip():
     first_octet = random.randint(192, 223)
     second_octet = random.choice([x for x in range(256) if x != 168])
     third_octet = random.randint(0, 255)
-    fourth_octet = random.randint(0, 254)
+    fourth_octet = random.randint(1, 254) # 0 is reserved base, 255 is reserved broadcast
 
     return f"{first_octet}.{second_octet}.{third_octet}.{fourth_octet}"
 


### PR DESCRIPTION
This will simply avoid generating the network address given a /24 CIDR. Broadcast address is already handled.
While an explanation in course instructions can be done for the next round, this will at least prevent accidental generation.

Explanatory comments added as well, and GitHub is adament about removing that ending newline somewhy.